### PR TITLE
justfile: add `--arch arm64 --arch x86_64` to build a universal binary

### DIFF
--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ default:
 build mode="debug":
     xcrun coremlcompiler generate Resources/TeemojiClassifier.mlpackage Sources --language Swift
     xcrun coremlcompiler compile Resources/TeemojiClassifier.mlpackage Sources
-    swift build --configuration {{mode}} --verbose --disable-sandbox
+    swift build --configuration {{mode}} --verbose --disable-sandbox --arch arm64 --arch x86_64
 
 test: (build "debug")
     swift test


### PR DESCRIPTION
This pull request adds `--arch arm64 --arch x86_64` to the swift build command. This fixes issue #7, as a universal binary will allow teemoji to run on both Apple Silicon and Intel Macs.