### PR TITLE
feat: add reverse option

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -2,20 +2,29 @@ name: PR Title Check
 
 on:
   pull_request:
-    branches:
-      - main
+    branches: [main]
+    types: [milestoned, opened, edited, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
-  check-title:
+  run:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Validate PR Title
+      - name: Setup Node.js
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+
+      - name: Install commitlint
         run: |
-          TITLE="${{ github.event.pull_request.title }}"
-          echo "PR Title: ${TITLE}"
-          # Adjust the regex as needed to match your conventional commit format.
-          if ! echo "${TITLE}" | grep -Eq "^(feat|fix|docs|style|refactor|perf|test|chore)(\([\w\-]+\))?: .+"; then
-            echo "Error: PR title does not match the conventional commit format."
-            exit 1
-          fi
+          npm install --save-dev @commitlint/config-conventional@19.6.0
+          npm install --save-dev @commitlint/cli@19.6.1
+
+      - name: Lint PR title
+        env:
+          pull_request_title: ${{ github.event.pull_request.title }}
+        run: |
+          echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
+          # shellcheck disable=SC2154
+          echo "$pull_request_title" | npx commitlint

--- a/Sources/Teemoji.swift
+++ b/Sources/Teemoji.swift
@@ -10,6 +10,7 @@ import Foundation
 struct Teemoji {
     struct ArgumentOptions {
         let append: Bool
+        let reverse: Bool
         let fileURLs: [URL]
         let shouldExit: Bool
     }
@@ -20,6 +21,7 @@ struct Teemoji {
 
         let appendFlagIndex = arguments.firstIndex(where: { $0 == "-a" || $0 == "--append" })
         let ignoreSigIntIndex = arguments.firstIndex(where: { $0 == "-i" })
+        let reverseEmojiIndex = arguments.firstIndex(where: { $0 == "-r" || $0 == "--reverse" })
         let helpFlagIndex = arguments.firstIndex(where: { $0 == "-h" || $0 == "--help" })
 
         let append = (appendFlagIndex != nil)
@@ -32,6 +34,11 @@ struct Teemoji {
             arguments.remove(at: index)
         }
 
+        let reverse = (reverseEmojiIndex != nil)
+        if let index = reverseEmojiIndex {
+            arguments.remove(at: index)
+        }
+
         if helpFlagIndex != nil {
             printUsage()
             exit(EXIT_SUCCESS)
@@ -39,6 +46,7 @@ struct Teemoji {
 
         return ArgumentOptions(
             append: append,
+            reverse: reverse,
             fileURLs: arguments.map { URL(fileURLWithPath: $0) },
             shouldExit: helpFlagIndex != nil
         )
@@ -135,7 +143,11 @@ struct Teemoji {
                 predictionLabel = "❓"
             }
 
-            let outputLine = "\(predictionLabel) \(line)\n"
+            var outputLine = "\(predictionLabel) \(line)\n"
+            if options.reverse {
+                outputLine = "\(line) \(predictionLabel)\n"
+            }
+
             if fputs(outputLine, stdout) < 0 {
                 exitStatus = 1
             }
@@ -150,12 +162,15 @@ struct Teemoji {
     /// Prints usage, matching FreeBSD tee's style.
     static func printUsage() {
         let usage = """
-            usage: teemoji [-ai] [file ...]
+            usage: teemoji [-air] [file ...]
 
-            Reads from standard input, writes to standard output and specified files, prepending an emoji
-            inferred by a Core ML model to each line. Options:
+            Reads from standard input, writes to standard output and specified files,
+            prepending an emoji inferred by a Core ML model to each line.
+            
+            Options:
               -a\tAppend to the given file(s), do not overwrite
               -i\tIgnore SIGINT
+              -r\tReverses where the emoji will be placed (at end of line)
               -h\tDisplay help (non-standard extension)
             """
         print(usage)

--- a/Tests/TeemojiTests.swift
+++ b/Tests/TeemojiTests.swift
@@ -86,6 +86,21 @@ final class TeemojiTests: XCTestCase {
         XCTAssertTrue(fileContent.contains("Appending Content"))
     }
 
+    func testReverseOption() throws {
+        let input = "Hello World"
+        let output = try runTeemoji(inputs: [input], arguments: ["-r"])
+
+        // Verify the output starts with the input text
+        XCTAssertTrue(
+            output.starts(with: input),
+            "With the reverse option enabled, the output should begin with the original input text.")
+
+        // Verify the output has changed
+        XCTAssertFalse(
+            output.starts(with: "\(input)\n"),
+            "Output should not end directly with the input, it should have an emoji suffix.")
+    }
+
     func testIgnoreSigInt() throws {
         // Simulate sending SIGINT using a process group or similar to make sure it's ignored
         // Note: This test requires specific setup and may not be fully feasible in some test environments


### PR DESCRIPTION
This PR adds an option to reverse the position where the emoji will be placed (to the end of each line).

<details>
<summary>Examples</summary>

Normal behaviour (`brew info xz`)
```
==> xz: stable 5.6.4 (bottled)
General-purpose data compression with high compression ratio
https://tukaani.org/xz/
Installed
/opt/homebrew/Cellar/xz/5.6.4 (96 files, 2.0MB) *
  Poured from bottle using the formulae.brew.sh API on 2025-01-31 at 11:14:34
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/x/xz.rb
License: 0BSD AND GPL-2.0-or-later
==> Analytics
install: 276,076 (30 days), 753,478 (90 days), 3,557,894 (365 days)
install-on-request: 72,609 (30 days), 197,061 (90 days), 944,506 (365 days)
build-error: 99 (30 days)
```

With teemoji (`brew info xz | teemoji`):
```
🐍 ==> xz: stable 5.6.4 (bottled)
🔥 General-purpose data compression with high compression ratio
🔗 https://tukaani.org/xz/
✅ Installed
🚧 /opt/homebrew/Cellar/xz/5.6.4 (96 files, 2.0MB) *
✂️   Poured from bottle using the formulae.brew.sh API on 2025-01-31 at 11:14:34
🔗 From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/x/xz.rb
⏳ License: 0BSD AND GPL-2.0-or-later
🔄 ==> Analytics
📈 install: 275,977 (30 days), 753,445 (90 days), 3,557,781 (365 days)
📈 install-on-request: 72,571 (30 days), 197,058 (90 days), 944,466 (365 days)
🚧 build-error: 99 (30 days)
```

With reversed option enabled (`brew info xz | teemoji -r`):
```
==> xz: stable 5.6.4 (bottled) 🐍
General-purpose data compression with high compression ratio 🔥
https://tukaani.org/xz/ 🔗
Installed ✅
/opt/homebrew/Cellar/xz/5.6.4 (96 files, 2.0MB) * 🚧
  Poured from bottle using the formulae.brew.sh API on 2025-01-31 at 11:14:34 ✂️
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/x/xz.rb 🔗
License: 0BSD AND GPL-2.0-or-later ⏳
==> Analytics 🔄
install: 275,977 (30 days), 753,445 (90 days), 3,557,781 (365 days) 📈
install-on-request: 72,571 (30 days), 197,058 (90 days), 944,466 (365 days) 📈
build-error: 99 (30 days) 🚧
```

Doing `brew info xz | teemoji -r | teemoji` allows emojis to be on both sides, though it relies on the first teemoji to finish printing:
```
🐍 ==> xz: stable 5.6.4 (bottled) 🐍
🔥 General-purpose data compression with high compression ratio 🔥
🔗 https://tukaani.org/xz/ 🔗
✅ Installed ✅
🚧 /opt/homebrew/Cellar/xz/5.6.4 (96 files, 2.0MB) * 🚧
✂️   Poured from bottle using the formulae.brew.sh API on 2025-01-31 at 11:14:34 ✂️
🔗 From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/x/xz.rb 🔗
⏳ License: 0BSD AND GPL-2.0-or-later ⏳
🔄 ==> Analytics 🔄
📈 install: 277,072 (30 days), 753,808 (90 days), 3,558,894 (365 days) 📈
📈 install-on-request: 73,035 (30 days), 197,164 (90 days), 944,950 (365 days) 📈
🚧 build-error: 99 (30 days) 🚧
```
</details>